### PR TITLE
Remove explicit Jessie from sources.list

### DIFF
--- a/out/devel_base/Dockerfile
+++ b/out/devel_base/Dockerfile
@@ -15,8 +15,10 @@ RUN  rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
 
 
 # temporarily (?) change mirror used
-RUN sed -i.bak 's!http://httpredir.debian.org/debian jessie main!http://mirrors.kernel.org/debian jessie main!' /etc/apt/sources.list
+# RUN sed -i.bak 's!http://httpredir.debian.org/debian jessie main!http://mirrors.kernel.org/debian jessie main!' /etc/apt/sources.list
 
+# temporarily (?) remove explicit jessie source
+RUN sed -i.bak -e '/deb http:..ftp.de.debian.org.debian jessie main/d' /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get -y -t unstable install gdb libxml2-dev python-pip

--- a/out/release_base/Dockerfile
+++ b/out/release_base/Dockerfile
@@ -15,8 +15,10 @@ RUN  rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
 
 
 # temporarily (?) change mirror used
-RUN sed -i.bak 's!http://httpredir.debian.org/debian jessie main!http://mirrors.kernel.org/debian jessie main!' /etc/apt/sources.list
+# RUN sed -i.bak 's!http://httpredir.debian.org/debian jessie main!http://mirrors.kernel.org/debian jessie main!' /etc/apt/sources.list
 
+# temporarily (?) remove explicit jessie source
+RUN sed -i.bak -e '/deb http:..ftp.de.debian.org.debian jessie main/d' /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get -y -t unstable install gdb libxml2-dev python-pip

--- a/src/base/Dockerfile.in
+++ b/src/base/Dockerfile.in
@@ -15,8 +15,10 @@ RUN  rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
 
 
 # temporarily (?) change mirror used
-RUN sed -i.bak 's!http://httpredir.debian.org/debian jessie main!http://mirrors.kernel.org/debian jessie main!' /etc/apt/sources.list
+# RUN sed -i.bak 's!http://httpredir.debian.org/debian jessie main!http://mirrors.kernel.org/debian jessie main!' /etc/apt/sources.list
 
+# temporarily (?) remove explicit jessie source
+RUN sed -i.bak -e '/deb http:..ftp.de.debian.org.debian jessie main/d' /etc/apt/sources.list
 
 RUN apt-get update && \
     apt-get -y -t unstable install gdb libxml2-dev python-pip


### PR DESCRIPTION
Hi, as per request, I now have removed the `http://ftp.de.debian.org.debian jessie` from sources.list, 
which came in from the rocker/rstudio image. I also commented out the change to mirrors.kernel.org which was not applicable anymore, this can be removed in the future. Yours, Steffen
