### PR TITLE
Update dockerfiles to new release/devel, fix build for metabolomics

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -17,7 +17,7 @@ end
 CONFIG = YAML.load_file "config.yml"
 SEP = File::SEPARATOR
 REPO = 'bioconductor' # That's the username in the URL https://hub.docker.com/r/bioconductor/release_base/
-REPO = 'sneumann' # That's the username in the URL https://hub.docker.com/r/bioconductor/release_base/
+#REPO = 'sneumann' # That's the username in the URL https://hub.docker.com/r/bioconductor/release_base/
 
 @docker_setup = nil
 

--- a/Rakefile
+++ b/Rakefile
@@ -17,6 +17,7 @@ end
 CONFIG = YAML.load_file "config.yml"
 SEP = File::SEPARATOR
 REPO = 'bioconductor' # That's the username in the URL https://hub.docker.com/r/bioconductor/release_base/
+REPO = 'sneumann' # That's the username in the URL https://hub.docker.com/r/bioconductor/release_base/
 
 @docker_setup = nil
 
@@ -66,7 +67,8 @@ for version_name in CONFIG['versions'].keys
            today = Time.now.strftime "%Y%m%d"
            puts "checking for existing image #{t.name}:#{today}...."
            images = Docker::Image.all
-           existing = images.find {|i|i.info['RepoTags'].include? "#{REPO}/#{t.name}:#{today}"}
+	   existing = images.find { |i| (i.info['RepoTags'] || []).include? "#{REPO}/#{t.name}:#{today}" }
+
            unless existing.nil?
                puts "found an existing image with id #{existing.id}..."
            end
@@ -153,8 +155,8 @@ for version_name in CONFIG['versions'].keys
                     # make a read/only copy to get around some weirdness
                     rodata = CONFIG.dup['containers'][cont_name]
                     data = rodata.dup
-                    if data['parent'].start_with? "#{REPO}/"
-                        data['parent'] = rodata['parent'].sub("#{REPO}/", "#{REPO}/#{version}_")
+                    if data['parent'].start_with? "bioconductor/"
+                        data['parent'] = rodata['parent'].sub("bioconductor/", "#{REPO}/#{version}_")
                     end
                     if data['parent'] == 'bogus'
                       data['parent'] = vhash['parent']

--- a/common/installFromBiocViews.R.in
+++ b/common/installFromBiocViews.R.in
@@ -54,11 +54,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 <% if is_devel %>
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+<% end %>
+
+
+<% if is_devel %>
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 <% end %>
 

--- a/config.yml
+++ b/config.yml
@@ -1,17 +1,17 @@
 ---
 versions:
     release:
-        version_number: "3.3" # change this at release time
+        version_number: "3.4" # change this at release time
         r_url: "http://cran.fhcrc.org/src/base/R-latest.tar.gz"
         parent: "rocker/rstudio"
         use_r_devel: false # should always be false
     devel:
-        version_number: "3.4" # change this at release time
+        version_number: "3.5" # change this at release time
         ## IMPORTANT: Change r_url at release time if new bioc devel does(not) use R-devel
-        parent: "rocker/rstudio" # should be rocker/rstudio-daily if
+        parent: "rocker/rstudio-daily" # should be rocker/rstudio-daily if
                                  # use_r_devel is true, otherwise
                                  # rocker/rstudio
-        use_r_devel: false # true half the year
+        use_r_devel: true # true half the year
         # The following variable (use_numbered_branch) is only relevant if
         # use_r_devel is true.
         # use_numbered_branch should be false OR should be the (quoted) version number from
@@ -22,7 +22,7 @@ versions:
         # the R in trunk became R-3.3. However, the contemporaneous Bioconductor
         # devel branch uses R-3.2, NOT 3.3, so we would set the below variable
         # to "3.2" (be sure to quote the value so it's forced to be a string).
-        use_numbered_branch: "false"
+        use_numbered_branch: false
 
 containers: # FIXME (?) rename this to 'images' (?)
     base:

--- a/out/devel_base/Dockerfile
+++ b/out/devel_base/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/devel_base.
+# The suggested name for this image is: sneumann/devel_base.
 
-FROM rocker/rstudio
+FROM rocker/rstudio-daily
 
 # FIXME? in release, default CRAN mirror is set to rstudio....should it be fhcrc?
 
@@ -31,6 +31,19 @@ RUN pip install awscli
 RUN apt-get -y -t unstable install --fix-missing \
     texlive texinfo  texlive-fonts-extra texlive-latex-extra
 
+
+
+
+# There should only be one version of R on this container
+#RUN dpkg --purge --force-depends r-base-core
+# FIXME figure out how to REALLY remove r-base-core and deps
+# so that it does not come back.
+
+RUN rm -rf /usr/lib/R/library /usr/bin/R /usr/bin/Rscript
+
+
+RUN dpkg --purge --force-depends r-base-core
+RUN rm -rf /usr/lib/R/library /usr/bin/R /usr/bin/Rscript
 
 
 

--- a/out/devel_base/install.R
+++ b/out/devel_base/install.R
@@ -1,7 +1,7 @@
 # DO NOT EDIT 'install.R'; instead, edit 'install.R.in' and
 # use 'rake' to generate 'install.R'.
 
-url <- "http://bioconductor.org/packages/3.4/bioc"
+url <- "http://bioconductor.org/packages/3.5/bioc"
 
 if ("BiocInstaller" %in% rownames(installed.packages()))
 	remove.packages("BiocInstaller")

--- a/out/devel_base/installFromBiocViews.R
+++ b/out/devel_base/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("none")
 
-url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.5/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -52,11 +52,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+
+
+
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 
 

--- a/out/devel_core/Dockerfile
+++ b/out/devel_core/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/devel_core.
+# The suggested name for this image is: sneumann/devel_core.
 
-FROM bioconductor/devel_base
+FROM sneumann/devel_base
 
 
 

--- a/out/devel_core/install.R
+++ b/out/devel_core/install.R
@@ -13,7 +13,8 @@ pkgs <- c(
 "biomaRt",
 "Biostrings",
 "BSgenome",
-"epivizr",
+# Temporarily disabled because it does not build in devel-3.5 yet
+#"epivizr",
 "GenomicFeatures",
 "GenomicRanges",
 "graph",
@@ -23,7 +24,8 @@ pkgs <- c(
 "knitr",
 "RBGL",
 "RCurl",
-"ReportingTools",
+# Temporarily disabled because it does not build in devel-3.5 yet
+# "ReportingTools",
 "Rgraphviz",
 "rmarkdown",
 "XML",

--- a/out/devel_core/installFromBiocViews.R
+++ b/out/devel_core/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("none")
 
-url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.5/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -52,11 +52,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+
+
+
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 
 

--- a/out/devel_flow/Dockerfile
+++ b/out/devel_flow/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/devel_flow.
+# The suggested name for this image is: sneumann/devel_flow.
 
-FROM bioconductor/devel_core
+FROM sneumann/devel_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -12,7 +12,7 @@ MAINTAINER maintainer@bioconductor.org
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN apt-get -t unstable install -y --force-yes libfreetype6
 RUN apt-get -t unstable install -y \
-    autoconf libcairo2-dev libgsl0-dev libgsl0ldbl libfftw3-dev \
+    autoconf libcairo2-dev libgsl-dev libgsl0ldbl libfftw3-dev \
     libgl1-mesa-dev libglu1-mesa-dev libhdf5-dev libjpeg-dev \
     libnetcdf-dev libtiff-dev libtool libxt-dev imagemagick
 

--- a/out/devel_flow/installFromBiocViews.R
+++ b/out/devel_flow/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("FlowCytometry")
 
-url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.5/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -52,11 +52,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+
+
+
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 
 

--- a/out/devel_metabolomics/Dockerfile
+++ b/out/devel_metabolomics/Dockerfile
@@ -2,26 +2,23 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/devel_metabolomics.
+# The suggested name for this image is: sneumann/devel_metabolomics.
 
-FROM bioconductor/devel_core
+FROM sneumann/devel_core
 
 MAINTAINER sneumann@ipb-halle.de
 
-# temporarily block dist-upgrade:
-#    apt-get dist-upgrade -y && \
+# temporarily DO NOT block dist-upgrade:
+RUN apt-get install -f -y
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
-
 
 # nuke cache dirs before installing pkgs; tip from Dirk E fixes broken img
 RUN  rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
 
-
-RUN apt-get install -y -t unstable --force-yes libfreetype6
-
 RUN apt-get update && \
-    apt-get install -y -t unstable \
+    apt-get install -y \
+    libfreetype6 \
     libcairo2-dev \
     libexpat1-dev \
     libgmp3-dev \
@@ -30,33 +27,25 @@ RUN apt-get update && \
     libopenbabel-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
+    libmpfr-dev \
+    pkg-config \
+    fftw3-dev \
+    libgtk2.0-dev \
+    libtiff5-dev \
+    libnetcdf-dev \
+    libmpfr-dev \
+    libnetcdf-dev \
+    liblapack-dev \
+    cmake \
     openjdk-8-jdk
 
+# 
+# RUN apt-get install -y \
+#     libbz2-dev liblzma-dev libpcre3-dev libpng-dev
+# 
 
-RUN apt-get install -y -t unstable \
-    libbz2-dev liblzma-dev libpcre3-dev libpng-dev
-
-
-
-# For tofsims
-RUN apt-get install -y -t unstable \
-    liblapack-dev cmake
-
-# For SUNDIAL
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-cvode0_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-cvodes1_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-ida1_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-kinsol0_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-nvecserial0_2.3.0-2_amd64.deb
-
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-serial_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-serial-dev_2.3.0-2_amd64.deb
-
-RUN dpkg -i libsundials-cvode0_2.3.0-2_amd64.deb libsundials-cvodes1_2.3.0-2_amd64.deb libsundials-ida1_2.3.0-2_amd64.deb libsundials-kinsol0_2.3.0-2_amd64.deb libsundials-nvecserial0_2.3.0-2_amd64.deb libsundials-serial_2.3.0-2_amd64.deb libsundials-serial-dev_2.3.0-2_amd64.deb
-
-RUN bash -i -c 'wget -O libSBML-5.10.2-core-src.tar.gz http://downloads.sourceforge.net/project/sbml/libsbml/5.10.2/stable/libSBML-5.10.2-core-src.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsbml%2Ffiles%2Flibsbml%2F5.10.2%2Fstable%2F && tar xzvf libSBML-5.10.2-core-src.tar.gz ; cd libsbml-5.10.2 && CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure && make && make install && ldconfig'
-RUN bash -i -c 'wget -O rsbml_2.31.0.tar.gz http://bioconductor.org/packages/3.4/bioc/src/contrib/rsbml_2.31.0.tar.gz && tar -xzvf rsbml_2.31.0.tar.gz && cd rsbml && R CMD INSTALL . '
+RUN bash -i -c 'wget -O libSBML-5.10.2-core-src.tar.gz http://downloads.sourceforge.net/project/sbml/libsbml/5.10.2/stable/libSBML-5.10.2-core-src.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsbml%2Ffiles%2Flibsbml%2F5.10.2%2Fstable%2F && tar xzvf libSBML-5.10.2-core-src.tar.gz ; cd libsbml-5.10.2 && CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure --prefix=/usr && make && make install && ldconfig'
 
 RUN R CMD javareconf
 
@@ -64,12 +53,10 @@ ENV NETCDF_INCLUDE=/usr/include
 
 ADD startx.sh /tmp/
 
-
 ADD installFromBiocViews.R /tmp/
 
 # invalidates cache every 24 hours
 ADD http://master.bioconductor.org/todays-date /tmp/
-
 
 RUN cd /tmp && \
     ./startx.sh && \

--- a/out/devel_metabolomics/installFromBiocViews.R
+++ b/out/devel_metabolomics/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Metabolomics")
 
-url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.5/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -52,11 +52,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+
+
+
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 
 

--- a/out/devel_microarray/Dockerfile
+++ b/out/devel_microarray/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/devel_microarray.
+# The suggested name for this image is: sneumann/devel_microarray.
 
-FROM bioconductor/devel_core
+FROM sneumann/devel_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -25,6 +25,11 @@ RUN apt-get clean -y && \
 
 
 
+RUN apt-get remove -y r-base-core
+RUN rm -rf /usr/lib/R/library
+
+
+
 RUN apt-get -t unstable install -y --force-yes libfreetype6
 
 RUN echo "" | sudo debconf-set-selections
@@ -39,7 +44,7 @@ RUN apt-get update -qq && \
     git \
     ggobi \
     libcairo2-dev \
-    libgsl0-dev \
+    libgsl-dev \
     libjpeg-dev \
     libgtk2.0-dev \
     libgl1-mesa-dev \

--- a/out/devel_microarray/installFromBiocViews.R
+++ b/out/devel_microarray/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Microarray")
 
-url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.5/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -52,11 +52,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+
+
+
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 
 

--- a/out/devel_proteomics/Dockerfile
+++ b/out/devel_proteomics/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/devel_proteomics.
+# The suggested name for this image is: sneumann/devel_proteomics.
 
-FROM bioconductor/devel_core
+FROM sneumann/devel_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -30,7 +30,7 @@ RUN apt-get update && \
     libopenbabel-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
     openjdk-8-jdk
 
 

--- a/out/devel_proteomics/installFromBiocViews.R
+++ b/out/devel_proteomics/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Proteomics")
 
-url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.5/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -52,11 +52,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+
+
+
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 
 

--- a/out/devel_sequencing/Dockerfile
+++ b/out/devel_sequencing/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/devel_sequencing.
+# The suggested name for this image is: sneumann/devel_sequencing.
 
-FROM bioconductor/devel_core
+FROM sneumann/devel_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -31,7 +31,7 @@ RUN apt-get update && \
     libcairo2-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
     libgtk2.0-dev \
     libncurses5-dev \
     openjdk-8-jdk \

--- a/out/devel_sequencing/installFromBiocViews.R
+++ b/out/devel_sequencing/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Sequencing")
 
-url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.5/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -52,11 +52,27 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
 
 
-
 # don't install these because ChemmineR which is missing in BioC 3.4 because 
 # so far it was never built successfully
-pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
-pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+# pkgs_to_install <- pkgs_to_install[grep("ChemmineR", pkgs_to_install, invert=TRUE)]
+# Actually, ChemmineR is installable IF gridExtra is installed manually
+
+if ("ChemmineR" %in% pkgs_to_install) 
+  pkgs_to_install <- c(pkgs_to_install, "gridExtra")
+
+#pkgs_to_install <- pkgs_to_install[grep("bioassayR", pkgs_to_install, invert=TRUE)]
+
+
+
+
+
+# don't install these because ReportingTools which is missing in BioC 3.5 because 
+# it depends on OrganismDbi which so far it was never built successfully
+
+pkgs_to_install <- pkgs_to_install[grep("ReportingTools", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("epivizr", pkgs_to_install, invert=TRUE)]
+pkgs_to_install <- pkgs_to_install[grep("ggbio", pkgs_to_install, invert=TRUE)]
 
 
 

--- a/out/release_base/Dockerfile
+++ b/out/release_base/Dockerfile
@@ -2,7 +2,7 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/release_base.
+# The suggested name for this image is: sneumann/release_base.
 
 FROM rocker/rstudio
 

--- a/out/release_base/install.R
+++ b/out/release_base/install.R
@@ -1,7 +1,7 @@
 # DO NOT EDIT 'install.R'; instead, edit 'install.R.in' and
 # use 'rake' to generate 'install.R'.
 
-url <- "http://bioconductor.org/packages/3.3/bioc"
+url <- "http://bioconductor.org/packages/3.4/bioc"
 
 if ("BiocInstaller" %in% rownames(installed.packages()))
 	remove.packages("BiocInstaller")

--- a/out/release_base/installFromBiocViews.R
+++ b/out/release_base/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("none")
 
-url <- "http://www.bioconductor.org/packages/3.3/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -50,6 +50,9 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 
 # don't install Rolexa - does not build (deprecated)
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
+
+
+
 
 
 

--- a/out/release_core/Dockerfile
+++ b/out/release_core/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/release_core.
+# The suggested name for this image is: sneumann/release_core.
 
-FROM bioconductor/release_base
+FROM sneumann/release_base
 
 
 

--- a/out/release_core/install.R
+++ b/out/release_core/install.R
@@ -13,7 +13,8 @@ pkgs <- c(
 "biomaRt",
 "Biostrings",
 "BSgenome",
-"epivizr",
+# Temporarily disabled because it does not build in devel-3.5 yet
+#"epivizr",
 "GenomicFeatures",
 "GenomicRanges",
 "graph",
@@ -23,7 +24,8 @@ pkgs <- c(
 "knitr",
 "RBGL",
 "RCurl",
-"ReportingTools",
+# Temporarily disabled because it does not build in devel-3.5 yet
+# "ReportingTools",
 "Rgraphviz",
 "rmarkdown",
 "XML",

--- a/out/release_core/installFromBiocViews.R
+++ b/out/release_core/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("none")
 
-url <- "http://www.bioconductor.org/packages/3.3/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -50,6 +50,9 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 
 # don't install Rolexa - does not build (deprecated)
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
+
+
+
 
 
 

--- a/out/release_flow/Dockerfile
+++ b/out/release_flow/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/release_flow.
+# The suggested name for this image is: sneumann/release_flow.
 
-FROM bioconductor/release_core
+FROM sneumann/release_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -12,7 +12,7 @@ MAINTAINER maintainer@bioconductor.org
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN apt-get -t unstable install -y --force-yes libfreetype6
 RUN apt-get -t unstable install -y \
-    autoconf libcairo2-dev libgsl0-dev libgsl0ldbl libfftw3-dev \
+    autoconf libcairo2-dev libgsl-dev libgsl0ldbl libfftw3-dev \
     libgl1-mesa-dev libglu1-mesa-dev libhdf5-dev libjpeg-dev \
     libnetcdf-dev libtiff-dev libtool libxt-dev imagemagick
 

--- a/out/release_flow/installFromBiocViews.R
+++ b/out/release_flow/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("FlowCytometry")
 
-url <- "http://www.bioconductor.org/packages/3.3/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -50,6 +50,9 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 
 # don't install Rolexa - does not build (deprecated)
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
+
+
+
 
 
 

--- a/out/release_metabolomics/Dockerfile
+++ b/out/release_metabolomics/Dockerfile
@@ -2,26 +2,23 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/release_metabolomics.
+# The suggested name for this image is: sneumann/release_metabolomics.
 
-FROM bioconductor/release_core
+FROM sneumann/release_core
 
 MAINTAINER sneumann@ipb-halle.de
 
-# temporarily block dist-upgrade:
-#    apt-get dist-upgrade -y && \
+# temporarily DO NOT block dist-upgrade:
+RUN apt-get install -f -y
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
-
 
 # nuke cache dirs before installing pkgs; tip from Dirk E fixes broken img
 RUN  rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
 
-
-RUN apt-get install -y -t unstable --force-yes libfreetype6
-
 RUN apt-get update && \
-    apt-get install -y -t unstable \
+    apt-get install -y \
+    libfreetype6 \
     libcairo2-dev \
     libexpat1-dev \
     libgmp3-dev \
@@ -30,29 +27,22 @@ RUN apt-get update && \
     libopenbabel-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
+    libmpfr-dev \
+    pkg-config \
+    fftw3-dev \
+    libgtk2.0-dev \
+    libtiff5-dev \
+    libnetcdf-dev \
+    libmpfr-dev \
+    libnetcdf-dev \
+    liblapack-dev \
+    cmake \
     openjdk-8-jdk
 
+# 
 
-
-# For tofsims
-RUN apt-get install -y -t unstable \
-    liblapack-dev cmake
-
-# For SUNDIAL
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-cvode0_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-cvodes1_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-ida1_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-kinsol0_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-nvecserial0_2.3.0-2_amd64.deb
-
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-serial_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-serial-dev_2.3.0-2_amd64.deb
-
-RUN dpkg -i libsundials-cvode0_2.3.0-2_amd64.deb libsundials-cvodes1_2.3.0-2_amd64.deb libsundials-ida1_2.3.0-2_amd64.deb libsundials-kinsol0_2.3.0-2_amd64.deb libsundials-nvecserial0_2.3.0-2_amd64.deb libsundials-serial_2.3.0-2_amd64.deb libsundials-serial-dev_2.3.0-2_amd64.deb
-
-RUN bash -i -c 'wget -O libSBML-5.10.2-core-src.tar.gz http://downloads.sourceforge.net/project/sbml/libsbml/5.10.2/stable/libSBML-5.10.2-core-src.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsbml%2Ffiles%2Flibsbml%2F5.10.2%2Fstable%2F && tar xzvf libSBML-5.10.2-core-src.tar.gz ; cd libsbml-5.10.2 && CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure && make && make install && ldconfig'
-RUN bash -i -c 'wget -O rsbml_2.31.0.tar.gz http://bioconductor.org/packages/3.4/bioc/src/contrib/rsbml_2.31.0.tar.gz && tar -xzvf rsbml_2.31.0.tar.gz && cd rsbml && R CMD INSTALL . '
+RUN bash -i -c 'wget -O libSBML-5.10.2-core-src.tar.gz http://downloads.sourceforge.net/project/sbml/libsbml/5.10.2/stable/libSBML-5.10.2-core-src.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsbml%2Ffiles%2Flibsbml%2F5.10.2%2Fstable%2F && tar xzvf libSBML-5.10.2-core-src.tar.gz ; cd libsbml-5.10.2 && CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure --prefix=/usr && make && make install && ldconfig'
 
 RUN R CMD javareconf
 
@@ -60,12 +50,10 @@ ENV NETCDF_INCLUDE=/usr/include
 
 ADD startx.sh /tmp/
 
-
 ADD installFromBiocViews.R /tmp/
 
 # invalidates cache every 24 hours
 ADD http://master.bioconductor.org/todays-date /tmp/
-
 
 RUN cd /tmp && \
     ./startx.sh && \

--- a/out/release_metabolomics/installFromBiocViews.R
+++ b/out/release_metabolomics/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Metabolomics")
 
-url <- "http://www.bioconductor.org/packages/3.3/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -50,6 +50,9 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 
 # don't install Rolexa - does not build (deprecated)
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
+
+
+
 
 
 

--- a/out/release_microarray/Dockerfile
+++ b/out/release_microarray/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/release_microarray.
+# The suggested name for this image is: sneumann/release_microarray.
 
-FROM bioconductor/release_core
+FROM sneumann/release_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -39,7 +39,7 @@ RUN apt-get update -qq && \
     git \
     ggobi \
     libcairo2-dev \
-    libgsl0-dev \
+    libgsl-dev \
     libjpeg-dev \
     libgtk2.0-dev \
     libgl1-mesa-dev \

--- a/out/release_microarray/installFromBiocViews.R
+++ b/out/release_microarray/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Microarray")
 
-url <- "http://www.bioconductor.org/packages/3.3/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -50,6 +50,9 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 
 # don't install Rolexa - does not build (deprecated)
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
+
+
+
 
 
 

--- a/out/release_proteomics/Dockerfile
+++ b/out/release_proteomics/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/release_proteomics.
+# The suggested name for this image is: sneumann/release_proteomics.
 
-FROM bioconductor/release_core
+FROM sneumann/release_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -30,7 +30,7 @@ RUN apt-get update && \
     libopenbabel-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
     openjdk-8-jdk
 
 

--- a/out/release_proteomics/installFromBiocViews.R
+++ b/out/release_proteomics/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Proteomics")
 
-url <- "http://www.bioconductor.org/packages/3.3/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -50,6 +50,9 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 
 # don't install Rolexa - does not build (deprecated)
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
+
+
+
 
 
 

--- a/out/release_sequencing/Dockerfile
+++ b/out/release_sequencing/Dockerfile
@@ -2,9 +2,9 @@
 # generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
 # with the 'rake' command.
 
-# The suggested name for this image is: bioconductor/release_sequencing.
+# The suggested name for this image is: sneumann/release_sequencing.
 
-FROM bioconductor/release_core
+FROM sneumann/release_core
 
 MAINTAINER maintainer@bioconductor.org
 
@@ -29,7 +29,7 @@ RUN apt-get update && \
     libcairo2-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
     libgtk2.0-dev \
     libncurses5-dev \
     openjdk-8-jdk \

--- a/out/release_sequencing/installFromBiocViews.R
+++ b/out/release_sequencing/installFromBiocViews.R
@@ -9,7 +9,7 @@ biocLite(ask=FALSE)
 
 wantedBiocViews <- c("Sequencing")
 
-url <- "http://www.bioconductor.org/packages/3.3/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.4/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)
@@ -50,6 +50,9 @@ pkgs_to_install <- pkgs_to_install[grep("rMAT", pkgs_to_install, invert=TRUE)]
 
 # don't install Rolexa - does not build (deprecated)
 pkgs_to_install <- pkgs_to_install[grep("Rolexa", pkgs_to_install, invert=TRUE)]
+
+
+
 
 
 

--- a/src/core/install.R.in
+++ b/src/core/install.R.in
@@ -13,7 +13,8 @@ pkgs <- c(
 "biomaRt",
 "Biostrings",
 "BSgenome",
-"epivizr",
+# Temporarily disabled because it does not build in devel-3.5 yet
+#"epivizr",
 "GenomicFeatures",
 "GenomicRanges",
 "graph",
@@ -23,7 +24,8 @@ pkgs <- c(
 "knitr",
 "RBGL",
 "RCurl",
-"ReportingTools",
+# Temporarily disabled because it does not build in devel-3.5 yet
+# "ReportingTools",
 "Rgraphviz",
 "rmarkdown",
 "XML",

--- a/src/flow/Dockerfile.in
+++ b/src/flow/Dockerfile.in
@@ -12,7 +12,7 @@ MAINTAINER maintainer@bioconductor.org
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
 RUN apt-get -t unstable install -y --force-yes libfreetype6
 RUN apt-get -t unstable install -y \
-    autoconf libcairo2-dev libgsl0-dev libgsl0ldbl libfftw3-dev \
+    autoconf libcairo2-dev libgsl-dev libgsl0ldbl libfftw3-dev \
     libgl1-mesa-dev libglu1-mesa-dev libhdf5-dev libjpeg-dev \
     libnetcdf-dev libtiff-dev libtool libxt-dev imagemagick
 

--- a/src/metabolomics/Dockerfile.in
+++ b/src/metabolomics/Dockerfile.in
@@ -8,20 +8,17 @@ FROM <%= parent %>
 
 MAINTAINER sneumann@ipb-halle.de
 
-# temporarily block dist-upgrade:
-#    apt-get dist-upgrade -y && \
+# temporarily DO NOT block dist-upgrade:
+RUN apt-get install -f -y
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get update
-
 
 # nuke cache dirs before installing pkgs; tip from Dirk E fixes broken img
 RUN  rm -f /var/lib/dpkg/available && rm -rf  /var/cache/apt/*
 
-
-RUN apt-get install -y -t unstable --force-yes libfreetype6
-
 RUN apt-get update && \
-    apt-get install -y -t unstable \
+    apt-get install -y \
+    libfreetype6 \
     libcairo2-dev \
     libexpat1-dev \
     libgmp3-dev \
@@ -30,33 +27,25 @@ RUN apt-get update && \
     libopenbabel-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
+    libmpfr-dev \
+    pkg-config \
+    fftw3-dev \
+    libgtk2.0-dev \
+    libtiff5-dev \
+    libnetcdf-dev \
+    libmpfr-dev \
+    libnetcdf-dev \
+    liblapack-dev \
+    cmake \
     openjdk-8-jdk
 
-<% if is_devel %>
-RUN apt-get install -y -t unstable \
-    libbz2-dev liblzma-dev libpcre3-dev libpng-dev
+# <% if is_devel %>
+# RUN apt-get install -y \
+#     libbz2-dev liblzma-dev libpcre3-dev libpng-dev
+# <% end %>
 
-<% end %>
-
-# For tofsims
-RUN apt-get install -y -t unstable \
-    liblapack-dev cmake
-
-# For SUNDIAL
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-cvode0_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-cvodes1_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-ida1_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-kinsol0_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-nvecserial0_2.3.0-2_amd64.deb
-
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-serial_2.3.0-2_amd64.deb
-RUN wget http://snapshot.debian.org/archive/debian/20100407T220820Z/pool/main/s/sundials/libsundials-serial-dev_2.3.0-2_amd64.deb
-
-RUN dpkg -i libsundials-cvode0_2.3.0-2_amd64.deb libsundials-cvodes1_2.3.0-2_amd64.deb libsundials-ida1_2.3.0-2_amd64.deb libsundials-kinsol0_2.3.0-2_amd64.deb libsundials-nvecserial0_2.3.0-2_amd64.deb libsundials-serial_2.3.0-2_amd64.deb libsundials-serial-dev_2.3.0-2_amd64.deb
-
-RUN bash -i -c 'wget -O libSBML-5.10.2-core-src.tar.gz http://downloads.sourceforge.net/project/sbml/libsbml/5.10.2/stable/libSBML-5.10.2-core-src.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsbml%2Ffiles%2Flibsbml%2F5.10.2%2Fstable%2F && tar xzvf libSBML-5.10.2-core-src.tar.gz ; cd libsbml-5.10.2 && CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure && make && make install && ldconfig'
-RUN bash -i -c 'wget -O rsbml_2.31.0.tar.gz http://bioconductor.org/packages/3.4/bioc/src/contrib/rsbml_2.31.0.tar.gz && tar -xzvf rsbml_2.31.0.tar.gz && cd rsbml && R CMD INSTALL . '
+RUN bash -i -c 'wget -O libSBML-5.10.2-core-src.tar.gz http://downloads.sourceforge.net/project/sbml/libsbml/5.10.2/stable/libSBML-5.10.2-core-src.tar.gz?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fsbml%2Ffiles%2Flibsbml%2F5.10.2%2Fstable%2F && tar xzvf libSBML-5.10.2-core-src.tar.gz ; cd libsbml-5.10.2 && CXXFLAGS=-fPIC CFLAGS=-fPIC ./configure --prefix=/usr && make && make install && ldconfig'
 
 RUN R CMD javareconf
 
@@ -64,12 +53,10 @@ ENV NETCDF_INCLUDE=/usr/include
 
 ADD startx.sh /tmp/
 
-
 ADD installFromBiocViews.R /tmp/
 
 # invalidates cache every 24 hours
 ADD http://master.bioconductor.org/todays-date /tmp/
-
 
 RUN cd /tmp && \
     ./startx.sh && \

--- a/src/microarray/Dockerfile.in
+++ b/src/microarray/Dockerfile.in
@@ -44,7 +44,7 @@ RUN apt-get update -qq && \
     git \
     ggobi \
     libcairo2-dev \
-    libgsl0-dev \
+    libgsl-dev \
     libjpeg-dev \
     libgtk2.0-dev \
     libgl1-mesa-dev \

--- a/src/proteomics/Dockerfile.in
+++ b/src/proteomics/Dockerfile.in
@@ -30,7 +30,7 @@ RUN apt-get update && \
     libopenbabel-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
     openjdk-8-jdk
 
 <% if is_devel %>

--- a/src/sequencing/Dockerfile.in
+++ b/src/sequencing/Dockerfile.in
@@ -31,7 +31,7 @@ RUN apt-get update && \
     libcairo2-dev \
     libgl1-mesa-dev \
     libglu1-mesa-dev \
-    libgsl0-dev \
+    libgsl-dev \
     libgtk2.0-dev \
     libncurses5-dev \
     openjdk-8-jdk \


### PR DESCRIPTION
Hi,
here's another set of commits. These build on https://hub.docker.com/r/sneumann/

General:
- Change config.yml to use current release/devel branches
- Disable including ReportingTools and others depending on OrganismDbi which doesn't exist yet in devel
- use libgsl-dev instead of libgsl0-dev

Metabolomics:
- Re-enable ChemmineR which builds now

Don't hesitate to ask if I missed/messed up anything.

Yours, Steffen
