### PR TITLE
Adds mscore and proteomics containers

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,3 +38,10 @@ containers: # FIXME (?) rename this to 'images' (?)
         parent: bioconductor/protmetcore
         biocViews:
             - Metabolomics
+    mscore:
+        parent: bioconductor/base
+    proteomics:
+        parent: bioconductor/mscore
+        biocViews:
+            - Proteomics
+            - MassSpectrometryData        

--- a/src/mscore/Dockerfile.in
+++ b/src/mscore/Dockerfile.in
@@ -1,0 +1,45 @@
+# DO NOT EDIT FILES CALLED 'Dockerfile'; they are automatically
+# generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
+# with the 'rake' command.
+
+# The suggested name for this image is: <%= image_name %>.
+
+FROM <%= parent %>
+
+MAINTAINER lg390@cam.ac.uk
+
+RUN apt-get update -qq && \
+    apt-get install -y <% if is_devel %> -t unstable <% end %> --no-install-recommends \
+    libfreetype6 \
+    libcairo2-dev \
+    libexpat1-dev \
+    libgmp3-dev \
+    liblapack-dev \
+    libnetcdf-dev \
+    libopenbabel-dev \
+    libgl1-mesa-dev \
+    libglu1-mesa-dev \
+    libgsl0-dev \
+    libmpfr-dev \
+    pkg-config \
+    fftw3-dev \
+    libgtk2.0-dev \
+    libtiff5-dev \
+    libnetcdf-dev \
+    libmpfr-dev \
+    libnetcdf-dev \
+    liblapack-dev \
+    cmake \
+    default-jdk \
+    libnetcdf-dev libpng-dev libbz2-dev liblzma-dev libpcre3-dev libicu-dev
+
+RUN R CMD javareconf
+
+ENV NETCDF_INCLUDE=/usr/include
+
+ADD install.R /tmp/
+
+# invalidates cache every 24 hours
+ADD http://master.bioconductor.org/todays-date /tmp/
+
+RUN R -f /tmp/install.R

--- a/src/mscore/hooks/post_push
+++ b/src/mscore/hooks/post_push
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+# Parse image name for repo name
+tagStart=$(expr index "$IMAGE_NAME" :)  
+repoName=${IMAGE_NAME:0:tagStart-1}
+
+# Tag and push image for each additional tag
+#for tag in {16.04,latest}; do  
+#    docker tag $IMAGE_NAME ${repoName}:${tag}
+#    docker push ${repoName}:${tag}
+#done  
+
+dateTag=`date +%Y%m%d`
+docker tag $IMAGE_NAME ${repoName}:${dateTag}
+docker push ${repoName}:${dateTag}

--- a/src/mscore/install.R.in
+++ b/src/mscore/install.R.in
@@ -1,0 +1,28 @@
+# DO NOT EDIT 'install.R'; instead, edit 'install.R.in' and
+# use 'rake' to generate 'install.R'.
+
+library(BiocInstaller) # shouldn't be necessary
+
+pkgs <- c("biocViews", "ProtGenerics", "mzR", "msdata",
+          "BiocParallel", "knitr", "rmarkdown", "httr", "RCul", "XML",
+          "zlibbioc")
+
+ap.db <- available.packages(contrib.url(biocinstallRepos()))
+ap <- rownames(ap.db)
+
+pkgs_to_install <- pkgs[pkgs %in% ap]
+
+biocLite(pkgs_to_install)
+
+# just in case there were warnings, we want to see them
+# without having to scroll up:
+warnings()
+
+if (!is.null(warnings()))
+{
+    w <- capture.output(warnings())
+    if (length(grep("is not available|had non-zero exit status", w)))
+        quit("no", 1L)
+}
+
+suppressWarnings(BiocInstaller::biocValid(fix=TRUE, ask=FALSE))

--- a/src/proteomics/Dockerfile.in
+++ b/src/proteomics/Dockerfile.in
@@ -1,0 +1,16 @@
+# DO NOT EDIT FILES CALLED 'Dockerfile'; they are automatically
+# generated. Edit 'Dockerfile.in' and generate the 'Dockerfile'
+# with the 'rake' command.
+
+# The suggested name for this image is: <%= image_name %>.
+
+FROM <%= parent %>
+
+MAINTAINER lg390@cam.ac.uk
+
+ADD install.R /tmp/
+
+# invalidates cache every 24 hours
+ADD http://master.bioconductor.org/todays-date /tmp/
+
+RUN R -f /tmp/install.R

--- a/src/proteomics/install.R.in
+++ b/src/proteomics/install.R.in
@@ -1,0 +1,51 @@
+# DO NOT EDIT 'install.R'; instead, edit 'install.R.in' and
+# use 'rake' to generate 'install.R'.
+
+library(BiocInstaller) # shouldn't be necessary
+
+
+## Obtain list of packages in view, as defined in config.yml
+<% if defined? biocViews %>
+wantedBiocViews <- c(<%= biocViews.map{|i| '"' + i + '"'}.join(",")  %>)
+<% else %>
+wantedBiocViews <- c("none")
+<% end %>
+
+## software packages
+con1 <- url("http://www.bioconductor.org/packages/<%= bioc_version %>/bioc/VIEWS")
+dcf1 <- as.data.frame(read.dcf(con1), stringsAsFactors=FALSE)
+## data packages
+con2 <- url("http://www.bioconductor.org/packages/<%= bioc_version %>/data/experiment/VIEWS")
+dcf2 <- as.data.frame(read.dcf(con2), stringsAsFactors=FALSE)
+
+dcf <- rbind(dcf1[, c("Package", "biocViews")],
+             dcf2[, c("Package", "biocViews")])
+
+i <- lapply(wantedBiocViews, grep, dcf$biocViews)
+pkgs_matching_views <- dcf$Package[unique(unlist(i))]
+
+ap.db <- available.packages(contrib.url(biocinstallRepos()))
+ap <- rownames(ap.db)
+
+##
+## Selection and fine-tuning of packages to install
+##
+pkgs_to_install <- pkgs_matching_views[pkgs_matching_views %in% ap]
+
+# don't reinstall anything that's installed already
+pkgs_to_install <- setdiff(pkgs_to_install, rownames(installed.packages()))
+
+## Start the actual installation:
+biocLite(pkgs_to_install)
+
+# just in case there were warnings, we want to see them
+# without having to scroll up:
+warnings()
+
+if (!is.null(warnings())) {
+    w <- capture.output(warnings())
+    if (length(grep("is not available|had non-zero exit status", w)))
+        quit("no", 1L)
+}
+
+suppressWarnings(BiocInstaller::biocValid(fix=TRUE, ask=FALSE))


### PR DESCRIPTION
The `mscore` containers is a minimal container that contains a manually curated list of packages (see #14). The `proteomics` container includes the proteomics biocViews. 

Once these are up and running, I would like to add a couple of additional proteomics containers. Should I add these to my own of the Bioconductor docker hub?