### PR TITLE
Change protmetcore parent to mscore

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -30,7 +30,7 @@ containers: # FIXME (?) rename this to 'images' (?)
     core:
         parent: bioconductor/base
     protmetcore:
-        parent: bioconductor/core
+        parent: bioconductor/mscore
         biocViews:
             - Metabolomics
             - Proteomics


### PR DESCRIPTION
with some essential mass spectrometry related packages already in mscore, 
protmetcore (the intersection of BioCViews metabolomics and proteomics) 
should build faster.