### PR TITLE
Fix build errors in proteomics containers

### DIFF
--- a/src/mscore/Dockerfile.in
+++ b/src/mscore/Dockerfile.in
@@ -11,6 +11,7 @@ MAINTAINER lg390@cam.ac.uk
 RUN apt-get update -qq && \
     apt-get install -y <% if use_r_devel %> -t unstable <% end %> --no-install-recommends \
     libfreetype6 \
+    libxt-dev \
     libcairo2-dev \
     libexpat1-dev \
     libgmp3-dev \

--- a/src/proteomics/Dockerfile.in
+++ b/src/proteomics/Dockerfile.in
@@ -8,9 +8,6 @@ FROM <%= parent %>2
 
 MAINTAINER lg390@cam.ac.uk
 
-RUN apt-get update -qq && \
-    apt-get install -y libxt-dev
-
 ADD install.R /tmp/
 
 # invalidates cache every 24 hours

--- a/src/proteomics/Dockerfile.in
+++ b/src/proteomics/Dockerfile.in
@@ -8,6 +8,9 @@ FROM <%= parent %>2
 
 MAINTAINER lg390@cam.ac.uk
 
+RUN apt-get update -qq && \
+    apt-get install -y libxt-dev
+
 ADD install.R /tmp/
 
 # invalidates cache every 24 hours


### PR DESCRIPTION
I have added the missing apt dependency to `mscore`. 