### PR TITLE
Bug fix: .Rprofile needs to be in/home/rstudio, not in root.

### DIFF
--- a/src/base/Dockerfile.in
+++ b/src/base/Dockerfile.in
@@ -182,6 +182,6 @@ RUN apt-get update && apt-get -y install libpng-dev
 ADD install.R /tmp/
 
 RUN R -f /tmp/install.R && \
-    echo "library(BiocManager)" > $HOME/.Rprofile && \
-    echo ".libPaths('/usr/local/lib/R/host-site-library')" >> $HOME/.Rprofile
+    echo "library(BiocManager)" > /home/rstudio/.Rprofile && \
+    echo ".libPaths('/usr/local/lib/R/host-site-library')" >> /home/rstudio/.Rprofile
 


### PR DESCRIPTION
The mount path should be located from the '/home/rstudio/' through .Rprofile.

Otherwise it gets copied to the 'root' users ~/.Rprofile and .libPaths()
with the mount volume doesn't get recognized.

This should be changed everywhere, with all images as needed