### PR TITLE
remove spliceSites from build. Closes #55

### DIFF
--- a/src/proteomics/install.R.in
+++ b/src/proteomics/install.R.in
@@ -43,6 +43,8 @@ pkgs_to_install <- setdiff(pkgs_to_install, rownames(installed.packages()))
 
 # https://github.com/Bioconductor/bioc_docker/issues/58
 pkgs_to_install <- pkgs_to_install[!grepl("prot2D", pkgs_to_install)]
+# https://github.com/Bioconductor/bioc_docker/issues/55
+pkgs_to_install <- pkgs_to_install[!grepl("spliceSites", pkgs_to_install)]
 
 ## Start the actual installation:
 ok <- BiocManager::install(pkgs_to_install, update=FALSE, ask=FALSE) %in% rownames(installed.packages())


### PR DESCRIPTION
Ban spliceSites from being included, as it also fails on
http://bioconductor.org/checkResults/release/bioc-LATEST/spliceSites/
Yours, Steffen