### PR TITLE
Move R-devel version hack from core/Dockerfile.in to base/Dockerfile.in

### DIFF
--- a/out/devel_base/Dockerfile
+++ b/out/devel_base/Dockerfile
@@ -80,6 +80,11 @@ RUN apt-get update && apt-get -y install libpng-dev
 RUN apt-get update && apt-get -y install libbz2-dev liblzma-dev
 
 
+# Hack for https://github.com/Bioconductor/bioc_docker/issues/79
+RUN git clone https://git.bioconductor.org/packages/BiocVersion
+RUN sed -i -e 's/, R (< /, R (<= /' BiocVersion/DESCRIPTION 
+RUN R CMD INSTALL BiocVersion
+
 
 ADD install.R /tmp/
 

--- a/src/base/Dockerfile.in
+++ b/src/base/Dockerfile.in
@@ -182,7 +182,12 @@ RUN apt-get update && apt-get -y install libpng-dev
 # install headers needed for Rhtslib
 RUN apt-get update && apt-get -y install libbz2-dev liblzma-dev
 
-
+<% if is_devel %>
+# Hack for https://github.com/Bioconductor/bioc_docker/issues/79
+RUN git clone https://git.bioconductor.org/packages/BiocVersion
+RUN sed -i -e 's/, R (< /, R (<= /' BiocVersion/DESCRIPTION 
+RUN R CMD INSTALL BiocVersion
+<% end %>
 
 ADD install.R /tmp/
 

--- a/src/core/Dockerfile.in
+++ b/src/core/Dockerfile.in
@@ -13,12 +13,4 @@ ADD install.R /tmp/
 # invalidates cache every 24 hours
 ADD http://master.bioconductor.org/todays-date /tmp/
 
-# Hack for https://github.com/Bioconductor/bioc_docker/issues/79
-<% if is_devel %>
-RUN git clone https://git.bioconductor.org/packages/BiocVersion
-RUN sed -i -e 's/, R (< /, R (<= /' BiocVersion/DESCRIPTION 
-RUN R CMD INSTALL BiocVersion
-<% end %>
-
-
 RUN R -f /tmp/install.R


### PR DESCRIPTION
Hi, I realised no images based off `FROM devel_core2`, so instead the fix has to go into devel_base2.
This patch reverts the effect of #c252f2c3a71f3eb44bbce81f5e708aa497e4916f. Bonus:
This now also includes the changes to the `out/` files. Yours, Steffen