### PR TITLE
Update release tag and fix R version in config.yml

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -1,12 +1,12 @@
 ---
 versions:
     release:
-        version_number: "3.8" # change this at release time
+        version_number: "3.9" # change this at release time
         r_url: "https://cran.rstudio.com/src/base/R-latest.tar.gz"
-        parent: "rocker/rstudio:3.5.3"
+        parent: "rocker/rstudio:3.6.0"
         use_r_devel: false # should always be false
     devel:
-        version_number: "3.9" # change this at release time
+        version_number: "3.10" # change this at release time
         ## IMPORTANT: Change r_url at release time if new bioc devel does(not) use R-devel
         #parent: "rocker/rstudio:3.5.1"
         parent: "rocker/rstudio:devel"

--- a/config.yml
+++ b/config.yml
@@ -8,8 +8,8 @@ versions:
     devel:
         version_number: "3.10" # change this at release time
         ## IMPORTANT: Change r_url at release time if new bioc devel does(not) use R-devel
-        #parent: "rocker/rstudio:3.5.1"
-        parent: "rocker/rstudio:devel"
+        parent: "rocker/rstudio:3.6.0"
+        #parent: "rocker/rstudio:devel"
         # currently known bug/issue in rocker/rstudio-daily
         #"rocker/rstudio-daily" # should be rocker/rstudio-daily if
                                  # use_r_devel is true, otherwise

--- a/out/devel_base/Dockerfile
+++ b/out/devel_base/Dockerfile
@@ -4,7 +4,7 @@
 
 # The suggested name for this image is: bioconductor/devel_base.
 
-FROM rocker/rstudio:devel
+FROM rocker/rstudio:3.6.0
 
 # FIXME? in release, default CRAN mirror is set to rstudio....should it be fhcrc?
 

--- a/out/devel_base/install.R
+++ b/out/devel_base/install.R
@@ -9,8 +9,8 @@ install.packages("BiocManager", repos="https://cran.rstudio.com")
 #devtools::install_github("Bioconductor/BiocManager")
 library(BiocManager)
 
-if(BiocManager::version() != "3.9"){
-    BiocManager::install(version="3.9",
+if(BiocManager::version() != "3.10"){
+    BiocManager::install(version="3.10",
                          update=TRUE, ask=FALSE)
 }
 
@@ -19,5 +19,5 @@ builtins <- c("Matrix", "KernSmooth", "mgcv")
 for (builtin in builtins)
     if (!suppressWarnings(require(builtin, character.only=TRUE)))
         suppressWarnings(BiocManager::install(builtin,
-                                              version="3.9",
+                                              version="3.10",
                                               update=TRUE, ask=FALSE))

--- a/out/devel_metabolomics/Dockerfile
+++ b/out/devel_metabolomics/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update -qq && \
     libnetcdf-dev \
     liblapack-dev \
     cmake \
+    tcl8.6 tk8.6 \
     default-jdk \
     libnetcdf-dev libpng-dev libbz2-dev liblzma-dev libpcre3-dev libicu-dev \
     libudunits2-dev libgdal-dev

--- a/out/devel_metabolomics/install.R
+++ b/out/devel_metabolomics/install.R
@@ -8,7 +8,7 @@
 
 wantedBiocViews <- c("Metabolomics")
 
-url <- "http://www.bioconductor.org/packages/3.9/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.10/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)

--- a/out/devel_proteomics/install.R
+++ b/out/devel_proteomics/install.R
@@ -43,6 +43,8 @@ pkgs_to_install <- setdiff(pkgs_to_install, rownames(installed.packages()))
 pkgs_to_install <- pkgs_to_install[!grepl("prot2D", pkgs_to_install)]
 # https://github.com/Bioconductor/bioc_docker/issues/55
 pkgs_to_install <- pkgs_to_install[!grepl("spliceSites", pkgs_to_install)]
+# https://github.com/Bioconductor/bioc_docker/issues/86
+pkgs_to_install <- pkgs_to_install[!grepl("Rchemcpp", pkgs_to_install)]
 
 ## Start the actual installation:
 ok <- BiocManager::install(pkgs_to_install, update=FALSE, ask=FALSE) %in% rownames(installed.packages())

--- a/out/devel_proteomics/install.R
+++ b/out/devel_proteomics/install.R
@@ -9,10 +9,10 @@ wantedBiocViews <- c("Proteomics","MassSpectrometryData")
 install.packages("Cairo")
 
 ## software packages
-con1 <- url("http://www.bioconductor.org/packages/3.9/bioc/VIEWS")
+con1 <- url("http://www.bioconductor.org/packages/3.10/bioc/VIEWS")
 dcf1 <- as.data.frame(read.dcf(con1), stringsAsFactors=FALSE)
 ## data packages
-con2 <- url("http://www.bioconductor.org/packages/3.9/data/experiment/VIEWS")
+con2 <- url("http://www.bioconductor.org/packages/3.10/data/experiment/VIEWS")
 dcf2 <- as.data.frame(read.dcf(con2), stringsAsFactors=FALSE)
 
 dcf <- rbind(dcf1[, c("Package", "biocViews")],

--- a/out/devel_protmetcore/install.R
+++ b/out/devel_protmetcore/install.R
@@ -8,7 +8,7 @@
 
 wantedBiocViews <- c("Metabolomics","Proteomics")
 
-url <- "http://www.bioconductor.org/packages/3.9/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.10/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)

--- a/out/release_base/Dockerfile
+++ b/out/release_base/Dockerfile
@@ -4,7 +4,7 @@
 
 # The suggested name for this image is: bioconductor/release_base.
 
-FROM rocker/rstudio:3.5.3
+FROM rocker/rstudio:3.6.0
 
 # FIXME? in release, default CRAN mirror is set to rstudio....should it be fhcrc?
 

--- a/out/release_base/install.R
+++ b/out/release_base/install.R
@@ -9,8 +9,8 @@ install.packages("BiocManager", repos="https://cran.rstudio.com")
 #devtools::install_github("Bioconductor/BiocManager")
 library(BiocManager)
 
-if(BiocManager::version() != "3.8"){
-    BiocManager::install(version="3.8",
+if(BiocManager::version() != "3.9"){
+    BiocManager::install(version="3.9",
                          update=TRUE, ask=FALSE)
 }
 
@@ -19,5 +19,5 @@ builtins <- c("Matrix", "KernSmooth", "mgcv")
 for (builtin in builtins)
     if (!suppressWarnings(require(builtin, character.only=TRUE)))
         suppressWarnings(BiocManager::install(builtin,
-                                              version="3.8",
+                                              version="3.9",
                                               update=TRUE, ask=FALSE))

--- a/out/release_metabolomics/Dockerfile
+++ b/out/release_metabolomics/Dockerfile
@@ -30,8 +30,8 @@ RUN apt-get update -qq && \
     libnetcdf-dev \
     liblapack-dev \
     cmake \
-    default-jdk \
     tcl8.6 tk8.6 \
+    default-jdk \
     libnetcdf-dev libpng-dev libbz2-dev liblzma-dev libpcre3-dev libicu-dev \
     libudunits2-dev libgdal-dev
 

--- a/out/release_metabolomics/Dockerfile
+++ b/out/release_metabolomics/Dockerfile
@@ -31,7 +31,7 @@ RUN apt-get update -qq && \
     liblapack-dev \
     cmake \
     default-jdk \
-    tcl8.6 \
+    tcl8.6 tk8.6 \
     libnetcdf-dev libpng-dev libbz2-dev liblzma-dev libpcre3-dev libicu-dev \
     libudunits2-dev libgdal-dev
 

--- a/out/release_metabolomics/Dockerfile
+++ b/out/release_metabolomics/Dockerfile
@@ -31,6 +31,7 @@ RUN apt-get update -qq && \
     liblapack-dev \
     cmake \
     default-jdk \
+    tcl8.6 \
     libnetcdf-dev libpng-dev libbz2-dev liblzma-dev libpcre3-dev libicu-dev \
     libudunits2-dev libgdal-dev
 

--- a/out/release_metabolomics/install.R
+++ b/out/release_metabolomics/install.R
@@ -8,7 +8,7 @@
 
 wantedBiocViews <- c("Metabolomics")
 
-url <- "http://www.bioconductor.org/packages/3.8/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.9/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)

--- a/out/release_proteomics/install.R
+++ b/out/release_proteomics/install.R
@@ -43,6 +43,8 @@ pkgs_to_install <- setdiff(pkgs_to_install, rownames(installed.packages()))
 pkgs_to_install <- pkgs_to_install[!grepl("prot2D", pkgs_to_install)]
 # https://github.com/Bioconductor/bioc_docker/issues/55
 pkgs_to_install <- pkgs_to_install[!grepl("spliceSites", pkgs_to_install)]
+# https://github.com/Bioconductor/bioc_docker/issues/86
+pkgs_to_install <- pkgs_to_install[!grepl("Rchemcpp", pkgs_to_install)]
 
 ## Start the actual installation:
 ok <- BiocManager::install(pkgs_to_install, update=FALSE, ask=FALSE) %in% rownames(installed.packages())

--- a/out/release_proteomics/install.R
+++ b/out/release_proteomics/install.R
@@ -9,10 +9,10 @@ wantedBiocViews <- c("Proteomics","MassSpectrometryData")
 install.packages("Cairo")
 
 ## software packages
-con1 <- url("http://www.bioconductor.org/packages/3.8/bioc/VIEWS")
+con1 <- url("http://www.bioconductor.org/packages/3.9/bioc/VIEWS")
 dcf1 <- as.data.frame(read.dcf(con1), stringsAsFactors=FALSE)
 ## data packages
-con2 <- url("http://www.bioconductor.org/packages/3.8/data/experiment/VIEWS")
+con2 <- url("http://www.bioconductor.org/packages/3.9/data/experiment/VIEWS")
 dcf2 <- as.data.frame(read.dcf(con2), stringsAsFactors=FALSE)
 
 dcf <- rbind(dcf1[, c("Package", "biocViews")],

--- a/out/release_protmetcore/install.R
+++ b/out/release_protmetcore/install.R
@@ -8,7 +8,7 @@
 
 wantedBiocViews <- c("Metabolomics","Proteomics")
 
-url <- "http://www.bioconductor.org/packages/3.8/bioc/VIEWS"
+url <- "http://www.bioconductor.org/packages/3.9/bioc/VIEWS"
 
 t <- tempfile()
 download.file(url, t)

--- a/src/metabolomics/Dockerfile.in
+++ b/src/metabolomics/Dockerfile.in
@@ -30,6 +30,7 @@ RUN apt-get update -qq && \
     libnetcdf-dev \
     liblapack-dev \
     cmake \
+    tcl8.6 \
     default-jdk \
     libnetcdf-dev libpng-dev libbz2-dev liblzma-dev libpcre3-dev libicu-dev \
     libudunits2-dev libgdal-dev

--- a/src/metabolomics/Dockerfile.in
+++ b/src/metabolomics/Dockerfile.in
@@ -30,7 +30,7 @@ RUN apt-get update -qq && \
     libnetcdf-dev \
     liblapack-dev \
     cmake \
-    tcl8.6 \
+    tcl8.6 tk8.6 \
     default-jdk \
     libnetcdf-dev libpng-dev libbz2-dev liblzma-dev libpcre3-dev libicu-dev \
     libudunits2-dev libgdal-dev

--- a/src/proteomics/install.R.in
+++ b/src/proteomics/install.R.in
@@ -45,6 +45,8 @@ pkgs_to_install <- setdiff(pkgs_to_install, rownames(installed.packages()))
 pkgs_to_install <- pkgs_to_install[!grepl("prot2D", pkgs_to_install)]
 # https://github.com/Bioconductor/bioc_docker/issues/55
 pkgs_to_install <- pkgs_to_install[!grepl("spliceSites", pkgs_to_install)]
+# https://github.com/Bioconductor/bioc_docker/issues/86
+pkgs_to_install <- pkgs_to_install[!grepl("Rchemcpp", pkgs_to_install)]
 
 ## Start the actual installation:
 ok <- BiocManager::install(pkgs_to_install, update=FALSE, ask=FALSE) %in% rownames(installed.packages())


### PR DESCRIPTION
Hi, this is work in progress. 
In this PR, I can confirm successful local build for 
```
bioconductor/release_protcore2                       latest              4a4835c5f602        8 minutes ago       6.33GB
bioconductor/release_cytometry2                      latest              1ffdfff888d5        25 minutes ago      2.4GB
bioconductor/release_protmetcore2                    latest              a68f5aa2d777        34 minutes ago      5.13GB
bioconductor/release_mscore2                         latest              606e34d6e4dc        About an hour ago   3.21GB
bioconductor/release_core2                           latest              c0e6199b1adc        7 hours ago         2.15GB
bioconductor/release_base2                           latest              14d166fcec55        8 hours ago         1.64GB
```
still working on `release_proteomics2` and `release_metabolomics2`,
and the `devel_*` don't build due to `BiocVersion` not yet being ready for R-devel (3.7.0),
which will be adressed in https://github.com/Bioconductor/BiocVersion/pull/2
Yours, Steffen