### PR TITLE
Add libmariadb-dev instead of libmariadb-dev-compat

### DIFF
--- a/src/base/Dockerfile.in
+++ b/src/base/Dockerfile.in
@@ -20,7 +20,7 @@ RUN apt-get update && \
 	liblzma-dev \
 	libbz2-dev \
 	libpng-dev \
-	libmariadb-dev-compat \
+	libmariadb-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
 # issues with '/var/lib/dpkg/available' not found


### PR DESCRIPTION
For a few reasons,

    1. libmariadb-dev-compat causes RStudio to fail startup,

    ```
    [services.d] starting services
    /usr/lib/rstudio-server/bin/rserver: error while loading shared libraries: libssl.so.1.0.2: cannot open shared object file: No such file or directory
    [services.d] done.
    rsession: no process found
    ```

    This is because libmariadb-dev-compat introduces a new installation of libssl.so which isn't avialable on the machine (namely, libssl.so.1.0.0).

    This can be verified by, starting the docker image, then within `/usr/lib/x86_64-linux-gnu`,

    ```
    root@dfabeee53986:/usr/lib/x86_64-linux-gnu# ls libssl*
    libssl.a  libssl.so  libssl.so.1.0.0  libssl.so.1.1
    ```

    What we want from the image is to look exactly the same as from the rocker/rstudio:devel image which has,

    ```
    root@dfabeee53986:/usr/lib/x86_64-linux-gnu# ls libssl*
    libssl.a  libssl.so  libssl.so.1.1
    ```

    2. libmariadb-dev doesn't introduce the new installation of libssl.

    3. Allows RStudio startup and installation of packages like RMariaDB and GenomicFeatures without issues.

    libmariadb-dev-compat doesn't cause the same issue in RELEASE_3_10 image but we are changing it anyway. RStudio works as expected with the change.